### PR TITLE
Simulation/data

### DIFF
--- a/uav_collision_avoidance/main.py
+++ b/uav_collision_avoidance/main.py
@@ -82,13 +82,16 @@ def main(arg = None) -> None:
             file_path : str = "data/simulation-2024-05-14-11-42-37.csv"
             if len(args) > 1:
                 file_path = args[1]
-                if len(args) > 2:
+                test_id : int = 0
+                if len(args) == 2:
+                    test_id = int(args[2])
+                if len(args) > 3:
                     print(f"Invalid arguments: {args}")
                     logging.warning("Invalid arguments: %s", args)
             sim = Simulation(headless = True)
-            assert sim.load_simulation_data_from_file(file_path = file_path, test_id = 0, avoid_collisions = False)
+            assert sim.load_simulation_data_from_file(file_path = file_path, test_id = test_id, avoid_collisions = False)
             sim.run_headless(avoid_collisions = False)
-            assert sim.load_simulation_data_from_file(file_path = file_path, test_id = 0, avoid_collisions = True)
+            assert sim.load_simulation_data_from_file(file_path = file_path, test_id = test_id, avoid_collisions = True)
             sim.run_headless(avoid_collisions = True)
             QApplication.shutdown(app)
             sys.exit(0)

--- a/uav_collision_avoidance/src/simulation/simulation.py
+++ b/uav_collision_avoidance/src/simulation/simulation.py
@@ -226,7 +226,7 @@ class Simulation(QMainWindow):
         test_minimal_trigonometric_value : float = 0.00001
         test_course_difference_count : int = 170
         test_random_collision_course_differences : List[float] = random.uniform(test_minimal_course_difference, test_maximal_course_difference, test_course_difference_count).tolist()
-        test_random_collision_course_differences.sort(reverse = False)
+        # test_random_collision_course_differences.sort(reverse = False)
 
         # equal speeds, equal distances to cover, both climbing or both descending
         for angle in test_random_collision_course_differences:


### PR DESCRIPTION
## PR type

- [ ] Refactor
- [x] Feature
- [ ] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

When using "load" argument with specific file, now it is possible to load test index. Example:

```bash
python main.py load simulation.csv 5
```

This examples shows how to load test with index 5 (sixth test).
